### PR TITLE
Fix typo in readme

### DIFF
--- a/DiffAugment-stylegan2/README.md
+++ b/DiffAugment-stylegan2/README.md
@@ -56,7 +56,7 @@ Here, `WHICH_DATASET` specifies either `cifar10` or `cifar100` (default to `cifa
 | `mit-han-lab:stylegan2-cifar10-0.1.pkl` | `cifar10` (10% data) | 7.33 | 36.02 |
 | `mit-han-lab:DiffAugment-stylegan2-cifar10-0.1.pkl` | `cifar10` (10% data) | **8.84** | **14.50** |
 | `mit-han-lab:stylegan2-cifar100.pkl` | `cifar100` | 9.51 | 16.54 |
-| `mit-han-lab:DiffAugment-stylegan2-cifar10.pkl` | `cifar100` | **10.04** | **15.22** |
+| `mit-han-lab:DiffAugment-stylegan2-cifar100.pkl` | `cifar100` | **10.04** | **15.22** |
 | `mit-han-lab:stylegan2-cifar100-0.2.pkl` | `cifar100` (20% data) | 7.86 | 32.30 |
 | `mit-han-lab:DiffAugment-stylegan2-cifar100-0.2.pkl` | `cifar100` (20% data) | **9.82** | **16.65** |
 | `mit-han-lab:stylegan2-cifar100-0.1.pkl` | `cifar100` (10% data) | 7.01 | 45.87 |


### PR DESCRIPTION
The link to the stylegan2 cifar100 model has a typo.

PS I don't know why GitHub things line 149 has changed, it hasn't